### PR TITLE
Use Task.Run instead of Task.Factory.StartNew

### DIFF
--- a/Src/LiquidProjections.PollingEventStore/Subscription.cs
+++ b/Src/LiquidProjections.PollingEventStore/Subscription.cs
@@ -55,7 +55,7 @@ namespace LiquidProjections.PollingEventStore
                     CancellationToken = cancellationTokenSource.Token
                 };
 
-                Task = Task.Factory.StartNew(async () =>
+                Task = Task.Run(async () =>
                         {
                             try
                             {
@@ -72,10 +72,7 @@ namespace LiquidProjections.PollingEventStore
                                     exception);
                             }
                         },
-                        CancellationToken.None,
-                        TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
-                        TaskScheduler.Default)
-                    .Unwrap();
+                        CancellationToken.None);
             }
         }
 


### PR DESCRIPTION
`Task.Factory.StartNew` with `LongRunning `creates a dedicated non-pooled thread when the IO completion port is reached (somewhere in the first `await`) the background thread is released. So we essentially wasted a background thread per Subscription. 

`Task.Run` already does `DenyChildAttach` and unwraps the task Proxy (`Task<Task>`)