### PR TITLE
CheckpointRequestTimestamp turned into struct

### DIFF
--- a/Src/LiquidProjections.PollingEventStore/CheckpointRequestTimestamp.cs
+++ b/Src/LiquidProjections.PollingEventStore/CheckpointRequestTimestamp.cs
@@ -2,7 +2,7 @@
 
 namespace LiquidProjections.PollingEventStore
 {
-    internal sealed class CheckpointRequestTimestamp
+    internal struct CheckpointRequestTimestamp
     {
         public CheckpointRequestTimestamp(long previousCheckpoint, DateTime dateTimeUtc)
         {


### PR DESCRIPTION
I'm not 100% sure here but I think the field assignment should be atomic even with Volatile.Read it could be possible that you read the old value which can also happen if you just assign the field. Take this with a grain of salt and carefully review it.