### PR TITLE
Balancing the subscribers

### DIFF
--- a/Samples/SampleSubscriber/SampleSubscriber.csproj
+++ b/Samples/SampleSubscriber/SampleSubscriber.csproj
@@ -11,7 +11,4 @@
       <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.2" />
-  </ItemGroup>
 </Project>

--- a/Src/LiquidProjections.PollingEventStore/ISubscription.cs
+++ b/Src/LiquidProjections.PollingEventStore/ISubscription.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace LiquidProjections.PollingEventStore
+{
+    public interface ISubscription : IDisposable
+    {
+        /// <summary>
+        /// Returns a task that completes when the subscription has been completed disposed, including any background activity. 
+        /// </summary>
+        Task Disposed { get; }
+    }
+}

--- a/Src/LiquidProjections.PollingEventStore/Page.cs
+++ b/Src/LiquidProjections.PollingEventStore/Page.cs
@@ -18,5 +18,7 @@ namespace LiquidProjections.PollingEventStore
         public IReadOnlyList<Transaction> Transactions { get; }
 
         public long LastCheckpoint => Transactions.Count == 0 ? 0 : Transactions[Transactions.Count - 1].Checkpoint;
+
+        public bool IsEmpty => (Transactions.Count == 0);
     }
 }

--- a/Tests/LiquidProjections.PollingEventStore.Specs/LiquidProjections.PollingEventStore.Specs.csproj
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/LiquidProjections.PollingEventStore.Specs.csproj
@@ -30,23 +30,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chill, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Chill.3.0.1\lib\net45\Chill.dll</HintPath>
+    <Reference Include="Chill, Version=3.2.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Chill.3.2.0\lib\net45\Chill.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=3.4.2.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FakeItEasy.3.4.2\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=4.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c">
+      <HintPath>..\..\packages\FakeItEasy.4.6.0\lib\net45\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\..\packages\FluentAssertions.5.4.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="LiquidProjections.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\LiquidProjections.Abstractions.2.3.0\lib\netstandard1.1\LiquidProjections.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -67,6 +71,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TransactionBatchBuilder.cs" />
     <Compile Include="TransactionBuilder.cs" />
     <Compile Include="Event.cs" />
     <Compile Include="EventEnvelopeBuilder.cs" />

--- a/Tests/LiquidProjections.PollingEventStore.Specs/TransactionBatchBuilder.cs
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/TransactionBatchBuilder.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+
+namespace LiquidProjections.PollingEventStore.Specs
+{
+    public class TransactionBatchBuilder : TestDataBuilder<Transaction[]>
+    {
+        private long firstCheckpoint;
+        private int pageSize;
+
+        protected override Transaction[] OnBuild()
+        {
+            return Enumerable.Range((int)firstCheckpoint, pageSize)
+                .Select(cp => new TransactionBuilder().WithCheckpoint(cp).Build()).ToArray();
+        }
+
+        public TransactionBatchBuilder FollowingCheckpoint(long precedingCheckpoint)
+        {
+            firstCheckpoint = precedingCheckpoint + 1;
+            
+            return this;
+        }
+
+        public TransactionBatchBuilder WithPageSize(int pageSize)
+        {
+            this.pageSize = pageSize;
+            
+            return this;
+        }
+    }
+}

--- a/Tests/LiquidProjections.PollingEventStore.Specs/TransactionBuilder.cs
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/TransactionBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 
 namespace LiquidProjections.PollingEventStore.Specs
 {

--- a/Tests/LiquidProjections.PollingEventStore.Specs/packages.config
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chill" version="3.0.1" targetFramework="net452" />
-  <package id="FakeItEasy" version="3.4.2" targetFramework="net452" />
-  <package id="FluentAssertions" version="4.19.3" targetFramework="net452" />
+  <package id="Chill" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="4.6.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
   <package id="LiquidProjections.Abstractions" version="2.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />


### PR DESCRIPTION
Introduced a page request queue so that a fast subscriber does not prevent slow subscribers from receiving pages of transactions. Also adds a lot of new tests to verify more edge cases and interoperability between pre-loading and caching.