### PR TITLE
Try use the page cache if a majority of the request is already cached

### DIFF
--- a/Samples/SampleSubscriber/Program.cs
+++ b/Samples/SampleSubscriber/Program.cs
@@ -20,7 +20,7 @@ namespace SampleSubscriber
 //            var adapter = new PollingEventStoreAdapter(new PassiveEventStore(), 50000, 5.Seconds(), 1000, () => DateTime.UtcNow, messageFunc => Console.WriteLine(messageFunc()));
             var adapter = new PollingEventStoreAdapter(new PassiveEventStore(), 50000, TimeSpan.FromSeconds(5), 1000, () => DateTime.UtcNow);
 
-            int maxSubscribers = 10;
+            int maxSubscribers = 50;
             
             for (int id = 0; id < maxSubscribers; id++)
             {
@@ -54,9 +54,12 @@ namespace SampleSubscriber
     internal class PassiveEventStore : IPassiveEventStore
     {
         private const long MaxCheckpoint = 100000;
+        private int nrRequests = 0;
         
         public IEnumerable<Transaction> GetFrom(long? previousCheckpoint)
         {
+            Interlocked.Increment(ref nrRequests);
+            
             previousCheckpoint = previousCheckpoint ?? 0;
             if (previousCheckpoint > MaxCheckpoint)
             {
@@ -81,6 +84,8 @@ namespace SampleSubscriber
             }
             
             Thread.Sleep(1000);
+            
+            Console.WriteLine($"Number of event store requests: {nrRequests}");
 
             return transactions;
         }


### PR DESCRIPTION
Just before the adapter is going to issue a request to the underlying event store for a queued request, it will first check to see if a majority of the requested page is already in the cache. I've experimented with different fill-factors. See the results below as well as a comparison with #14.


Situation | Subscribers | Caching / Fillfactor | Time-to-complete | Event Store requests
-- | -- | -- | -- | --
Without   #17 | 50 | 50000 | 3:31 | 204
With   #17 | 50 | 50000 /   25% | 1:57 | 100
With   #17 | 50 | 50000 /   50% | 1:52 | 100
With   #17 | 50 | 50000 /   75% | 2:01 | 100
With   #17 | 50 | 50000 /   90% | 1:55 | 100
With   #17 | 50 | 0 / na | 16:56 | 1012

Fixes #16 

Should be merged after #14 is. 