### PR TITLE
Add an API to allow waiting for a subscription to reach a certain checkbox.

### DIFF
--- a/LiquidProjections.PollingEventStore.sln.DotSettings
+++ b/LiquidProjections.PollingEventStore.sln.DotSettings
@@ -56,10 +56,12 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/Environment/ContinuousTesting/TriggerMode/@EntryValue">OnSave</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>

--- a/Samples/SampleSubscriber/SampleSubscriber.csproj
+++ b/Samples/SampleSubscriber/SampleSubscriber.csproj
@@ -6,9 +6,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Src\LiquidProjections.PollingEventStore\LiquidProjections.PollingEventStore.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>

--- a/Src/LiquidProjections.PollingEventStore/ISubscription.cs
+++ b/Src/LiquidProjections.PollingEventStore/ISubscription.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LiquidProjections.PollingEventStore
@@ -8,11 +9,33 @@ namespace LiquidProjections.PollingEventStore
 #else
     internal 
 #endif
-        interface ISubscription : IDisposable
+    interface ISubscription : IDisposable
     {
         /// <summary>
         /// Returns a task that completes when the subscription has been completed disposed, including any background activity. 
         /// </summary>
         Task Disposed { get; }
+
+        /// <summary>
+        /// Creates a task that will complete either when the subscription has processed the requested <paramref name="checkpoint"/> or
+        /// when the <paramref name="timeout"/> expired.
+        /// </summary>
+        /// <remarks>
+        /// Because of Task scheduling reasons, the task may complete with a delay. Depending on when the <paramref name="cancellationToken"/>
+        /// is cancelled, it may throw a <see cref="OperationCanceledException"/>.
+        /// </remarks>
+        Task<bool> CatchUpUntil(long checkpoint,
+            TimeSpan timeout = default(TimeSpan), CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Creates a task that will complete either when the subscription has processed all remaining transactions or
+        /// when the <paramref name="timeout"/> expired.
+        /// </summary>
+        /// <remarks>
+        /// Because of Task scheduling reasons, the task may complete with a delay. Depending on when the <paramref name="cancellationToken"/>
+        /// is cancelled, it may throw a <see cref="OperationCanceledException"/>.
+        /// </remarks>
+        Task<bool> CatchUp(
+            TimeSpan timeout = default(TimeSpan), CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/Src/LiquidProjections.PollingEventStore/ProgressTracker.cs
+++ b/Src/LiquidProjections.PollingEventStore/ProgressTracker.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LiquidProjections.PollingEventStore
+{
+    /// <summary>
+    /// Tracks the progress of an individual subscriber and allows interested parties to asynchronously
+    /// await a subscriber to catch-up to a certain point. 
+    /// </summary>
+    internal class ProgressTracker
+    {
+        private readonly LogMessage logger;
+        private readonly List<NotificationRequest> requests = new List<NotificationRequest>();
+        private readonly object syncObject = new object();
+
+        public ProgressTracker(long lastProcessedCheckpoint, LogMessage logger)
+        {
+            this.logger = logger;
+            LastProcessedCheckpoint = lastProcessedCheckpoint;
+        }
+
+        public long LastProcessedCheckpoint { get; private set; }
+
+        public async Task<bool> CatchUpUntil(long checkpoint, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (LastProcessedCheckpoint < checkpoint)
+            {
+                var request = NotificationRequest.For(checkpoint);
+
+                return await WaitForNotification(timeout, cancellationToken, request);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public Task<bool> CatchUp(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            var request = NotificationRequest.ForCatchup();
+
+            return WaitForNotification(timeout, cancellationToken, request);
+        }
+
+        private async Task<bool> WaitForNotification(TimeSpan timeout, CancellationToken cancellationToken,
+            NotificationRequest request)
+        {
+            logger(() => $"Wait until subscription has caught up until {request.ExpectedCheckpoint}");
+
+            lock (syncObject)
+            {
+                requests.Add(request);
+            }
+
+            cancellationToken.Register(() =>
+            {
+                lock (syncObject)
+                {
+                    requests.Remove(request);
+                }
+            });
+
+            bool completedInTime = await request.Completed.Task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+
+            lock (syncObject)
+            {
+                requests.Remove(request);
+            }
+
+            return completedInTime;
+        }
+
+        public void TrackProgress(long lastProcessedCheckpoint)
+        {
+            LastProcessedCheckpoint = lastProcessedCheckpoint;
+            Notify(lastProcessedCheckpoint);
+        }
+
+        public void TrackCatchUp()
+        {
+            Notify(null);
+        }
+
+        private void Notify(long? lastProcessedCheckpoint)
+        {
+            NotificationRequest[] notificationRequests;
+
+            lock (syncObject)
+            {
+                notificationRequests = requests
+                    .Where(request => HasReachedExpectation(lastProcessedCheckpoint, request.ExpectedCheckpoint))
+                    .ToArray();
+            }
+
+            foreach (NotificationRequest request in notificationRequests)
+            {
+                logger(() =>
+                    $"Notifying subscriber waiting for {request.ExpectedCheckpoint} that we processed {lastProcessedCheckpoint}");
+
+                request.Completed.SetResult(new object());
+
+                lock (syncObject)
+                {
+                    requests.Remove(request);
+                }
+            }
+        }
+
+        private static bool HasReachedExpectation(long? lastProcessedCheckpoint, long? expectedCheckpoint)
+        {
+            return (!lastProcessedCheckpoint.HasValue && !expectedCheckpoint.HasValue) ||
+                   (lastProcessedCheckpoint.HasValue && expectedCheckpoint.HasValue &&
+                    lastProcessedCheckpoint >= expectedCheckpoint);
+        }
+
+        /// <summary>
+        /// Represents a request to complete the task identified by <see cref="Completed"/> either when a subscription reaches the checkpoint
+        /// set through <see cref="ExpectedCheckpoint"/> or when the subscription caught up with all pending transactions. In that case,
+        /// <see cref="ExpectedCheckpoint"/> is <c>null</c>.    
+        /// </summary>
+        private class NotificationRequest
+        {
+            public static NotificationRequest For(long checkpoint)
+            {
+                return new NotificationRequest(checkpoint);
+            }
+
+            public TaskCompletionSource<object> Completed { get; }
+
+            public long? ExpectedCheckpoint { get; }
+
+            public static NotificationRequest ForCatchup()
+            {
+                return new NotificationRequest(null);
+            }
+
+            private NotificationRequest(long? checkpoint)
+            {
+                ExpectedCheckpoint = checkpoint;
+                Completed = new TaskCompletionSource<object>();
+            }
+        }
+    }
+}

--- a/Src/LiquidProjections.PollingEventStore/TaskExtensions.cs
+++ b/Src/LiquidProjections.PollingEventStore/TaskExtensions.cs
@@ -40,5 +40,45 @@ namespace LiquidProjections.PollingEventStore
 
             return tcs.Task;
         }
+
+        /// <summary>
+        /// Waits for a task to complete, but not longer than the specified <paramref name="timeout"/>.
+        /// </summary>
+        /// <returns>
+        /// Returns <c>true</c> if the long-running operation completed. Returns <c>false</c>
+        /// if the wait timed out. Throws a <see cref="OperationCanceledException"/> if the <paramref name="cancellationToken"/>
+        /// was triggered.
+        /// </returns>
+        public static async Task<bool> WaitAsync(this Task longOperation, TimeSpan timeout, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (timeout != default(TimeSpan))
+            {
+                var delayCancellationSource = new CancellationTokenSource();
+
+                Task delay = Task.Delay(timeout, 
+                    CancellationTokenSource.CreateLinkedTokenSource(delayCancellationSource.Token, cancellationToken).Token);
+
+                Task completedTask = await Task.WhenAny(longOperation, delay);
+                if (completedTask == longOperation)
+                {
+                    delayCancellationSource.Cancel();
+
+                    await longOperation;  // Very important in order to propagate exceptions
+
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                await longOperation;
+
+                return true;
+            }
+        } 
     }
 }

--- a/Tests/LiquidProjections.PollingEventStore.Specs/LiquidProjections.PollingEventStore.Specs.csproj
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/LiquidProjections.PollingEventStore.Specs.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\..\packages\FakeItEasy.4.6.0\lib\net45\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=5.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
-      <HintPath>..\..\packages\FluentAssertions.5.4.1\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.5.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\..\packages\FluentAssertions.5.5.3\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="LiquidProjections.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">

--- a/Tests/LiquidProjections.PollingEventStore.Specs/TaskExtensions.cs
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/TaskExtensions.cs
@@ -18,7 +18,7 @@ namespace LiquidProjections.PollingEventStore.Specs
             }
             else
             {
-                throw new TimeoutException("The operation has timed out.");
+                throw new TimeoutException($"The operation has timed out after {timeout}");
             }
         }
     }

--- a/Tests/LiquidProjections.PollingEventStore.Specs/packages.config
+++ b/Tests/LiquidProjections.PollingEventStore.Specs/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Chill" version="3.2.0" targetFramework="net452" />
   <package id="FakeItEasy" version="4.6.0" targetFramework="net452" />
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.5.3" targetFramework="net452" />
   <package id="LiquidProjections.Abstractions" version="2.3.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />

--- a/build.ps1
+++ b/build.ps1
@@ -89,7 +89,7 @@ if(!$PSScriptRoot){
 $TOOLS_DIR = Join-Path $PSScriptRoot "Build"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
-$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 


### PR DESCRIPTION
Adds the awaitable methods `CatchUpUntil` and `CatchUp` on the `ISubscription` interface so you can wait for a subscriber to process a particular checkpoint or wait until it caught up